### PR TITLE
Retrieving a variant type of SAFEARRAY

### DIFF
--- a/native/safearray.cpp
+++ b/native/safearray.cpp
@@ -61,7 +61,8 @@ SafeArrayXducer::JavaType SafeArrayXducer::toJava( JNIEnv* env, SAFEARRAY* value
 		return BasicArrayXducer<VT_VARIANT,xducer::VariantXducer>::toJava(env,value);
 	if((feature&FADF_HAVEVARTYPE) != 0)
 	{
-	    VARTYPE elemType = HIWORD(value->cLocks)&VT_TYPEMASK;
+		VARTYPE elemType;
+		SafeArrayGetVartype(value, &elemType);
 		for( Entry* e=entries; e->clazz!=NULL; e++ ) {
 			if(elemType==e->vt)
 				return e->toJava(env,value);


### PR DESCRIPTION
Retrieving a variant type as described in MSDN here: http://msdn.microsoft.com/en-us/library/ms221482(v=vs.85).aspx. Sometimes previous code returned incorrect type.
