### PR TITLE
Fixed issue 19 by handling unexpected Object.wait() wakeups

### DIFF
--- a/runtime/src/com4j/ComThread.java
+++ b/runtime/src/com4j/ComThread.java
@@ -206,7 +206,9 @@ public final class ComThread extends Thread {
 
             // wait for the completion
             try {
-                task.wait();
+            	while (!task.isDone()) {
+            		task.wait();
+            	}
             } catch (InterruptedException e) {
                 task.exception = e; // we got interrupted, so task.result will be invalid! 
             }

--- a/runtime/src/com4j/Task.java
+++ b/runtime/src/com4j/Task.java
@@ -9,6 +9,7 @@ import java.util.concurrent.Callable;
  * @author Kohsuke Kawaguchi (kk@kohsuke.org)
  */
 abstract class Task<T> implements Callable<T> {
+	private volatile boolean doneExecuting = false;
     public abstract T call();
 
 
@@ -49,10 +50,20 @@ abstract class Task<T> implements Callable<T> {
             result = call();
         } catch( Throwable e ) {
             exception = e;
+        } finally {
+        	doneExecuting = true;
         }
 
         // let the calling thread know that we are done.
         notify();
+    }
+    
+    /**
+     * Indicates whether this task is done executing
+     * @return {@literal true} if execution of the task is finished
+     */
+    public final boolean isDone() {
+    	return doneExecuting;
     }
 
     /**


### PR DESCRIPTION
As suggested by @mpoindexter, I've made this fix proposal for #19. I've made the assumption that Task objects are only used once and then thrown away, hope I haven't missed the mark completely. Anyway, with this fix in place, I was unable to reproduce the issue.
