### PR TITLE
Fixed issue 16 by removing from liveComObjects in dispose()

### DIFF
--- a/runtime/src/com4j/ComThread.java
+++ b/runtime/src/com4j/ComThread.java
@@ -243,6 +243,17 @@ public final class ComThread extends Thread {
     }
     
     /**
+     * Removes a {@link Com4jObject} from the live objects of this {@link ComThread}
+     * 
+     * @param r The {@link Com4jObject}
+     */
+    public synchronized void removeLiveObject( Com4jObject r ) {
+    	if (r instanceof Wrapper) {
+    		liveComObjects.remove(((Wrapper)r).ref);
+    	}
+    }
+    
+    /**
      * Checks if the current thread is a {@link ComThread}.
      */
     static boolean isComThread() {

--- a/runtime/src/com4j/Wrapper.java
+++ b/runtime/src/com4j/Wrapper.java
@@ -236,6 +236,7 @@ final class Wrapper implements InvocationHandler, Com4jObject {
             ref.releaseNative();
             ref.clear();
             isDisposed = true;
+            thread.removeLiveObject(this);
         }
     }
 


### PR DESCRIPTION
This change adds a method to remove references from the liveComObjects set in ComThread and calls it from Wrapper.dispose(). The effect is clearly visible in this plot from VisualVM (using the same test program as in my comment on issue #16):

![image](https://f.cloud.github.com/assets/3527671/1622220/6425ba34-56a1-11e3-9a86-c1752cda6b45.png)

The work threads and ComThread threads are now discarded on every iteration (as I suppose they should).
