### PR TITLE
Fix Variant conversion in same ComThread

### DIFF
--- a/runtime/src/main/java/com4j/Variant.java
+++ b/runtime/src/main/java/com4j/Variant.java
@@ -740,7 +740,7 @@ public final class Variant extends Number {
         // native method invocation changeType needs to happen in the COM thread, that is responsible for this variant
         // @see ComCollection#fetch
         ComThread t = thread != null ? thread : ComThread.get();
-        return t.execute(new Task<T>() {
+        return new Task<T>() {
             public T call() {
                 Com4jObject wrapper = convertTo(Com4jObject.class);
                 if(null == wrapper) {
@@ -751,7 +751,7 @@ public final class Variant extends Number {
                 wrapper.dispose();
                 return ret;
             }
-        });
+        }.execute(t);
     }
 
     /**


### PR DESCRIPTION
Variant conversion gets blocked when calling from same `ComThread`.
For example, this happens in asynchronous `COM` event handling when 
iterating  through properties of received `COM` object in event handler:
```Java
ISWbemSink sink = ClassFactory.createSWbemSink();
sink.advise(ISWbemSinkEvents.class,new ISWbemSinkEvents() {
    public void onObjectReady(ISWbemObject object, ISWbemNamedValueSet asyncContext) {
        System.out.println("Received event: " + object.getObjectText_(0));
        for (Com4jObject oprop: object.properties_()) {
           ISWbemProperty prop = oprop.queryInterface(ISWbemProperty.class);
           System.out.println(prop.name() + ": " + prop.value());
        }
    }
});
```
The above code will block in iterator part when retrieving and converting `Variant`s.
The solution is to do conversion in `Variant`'s `ComThread` if the same as calling `ComThread`.