### PR TITLE
Checking for Null to prevent NPE.

### DIFF
--- a/tlbimp/src/main/java/com4j/tlbimp/TypeBinding.java
+++ b/tlbimp/src/main/java/com4j/tlbimp/TypeBinding.java
@@ -66,6 +66,10 @@ final class TypeBinding {
      *      like declaring LPWSTR as "ushort*", etc.
      */
     public static TypeBinding bind( Generator g, IType t, String nameHint ) throws BindingException {
+    	if(t == null){
+        	throw new BindingException("NULL TypeBinding");
+        }
+    	
         IPrimitiveType pt = t.queryInterface(IPrimitiveType.class);
         if(pt!=null) {
             // primitive


### PR DESCRIPTION
I was getting an NPE while using tlbimp on Redemption.dll.  The stack trace pointed here, so I added a test for a null IType being passed in.  This may or may not be the right thing to do in this case, but it gets me past the NPE and the generated code seems to work fine.  Someone who knows com4j better should validate, though.
