### PR TITLE
Fix unadvise/EventProxy.close()

### DIFF
--- a/runtime/src/main/java/com4j/EventProxy.java
+++ b/runtime/src/main/java/com4j/EventProxy.java
@@ -25,6 +25,7 @@ final class EventProxy<T> implements EventCookie {
 
     private final EventInterfaceDescriptor<T> descriptor;
     private final T javaObject;
+    private final ComThread thread;
 
     /**
      * Pointer to the native proxy.
@@ -35,9 +36,10 @@ final class EventProxy<T> implements EventCookie {
      * Creates a new event proxy that implements the event interface {@code intf}
      * and delivers events to {@code javaObject}.
      */
-    EventProxy(Class<T> intf, T javaObject) {
+    EventProxy(Class<T> intf, T javaObject, ComThread thread) {
         this.descriptor = getDescriptor(intf);
         this.javaObject = javaObject;
+        this.thread = thread;
     }
 
     /**
@@ -50,7 +52,7 @@ final class EventProxy<T> implements EventCookie {
                     Native.unadvise(nativeProxy);
                     return null;
                 }
-            }.execute();
+            }.execute(thread);
             nativeProxy = 0;
         }
     }

--- a/runtime/src/main/java/com4j/Wrapper.java
+++ b/runtime/src/main/java/com4j/Wrapper.java
@@ -275,7 +275,7 @@ final class Wrapper implements InvocationHandler, Com4jObject {
                     throw new ComException("This object doesn't have event source",-1);
                 GUID iid = COM4J.getIID(eventInterface);
                 Com4jObject cp = cpc.FindConnectionPoint(iid);
-                EventProxy<T> proxy = new EventProxy<T>(eventInterface, object);
+                EventProxy<T> proxy = new EventProxy<T>(eventInterface, object, thread);
                 proxy.nativeProxy = Native.advise(cp.getPointer(), proxy,iid.v[0], iid.v[1]);
 
                 // clean up resources to be nice

--- a/runtime/src/main/java/com4j/Wrapper.java
+++ b/runtime/src/main/java/com4j/Wrapper.java
@@ -284,7 +284,7 @@ final class Wrapper implements InvocationHandler, Com4jObject {
 
                 return proxy;
             }
-        }.execute();
+        }.execute(thread);
     }
 
     @Override


### PR DESCRIPTION
Unadvising COM events needs to be done in the context of the owning COM object just as advising them needs to.
Therefor closing an EventProxy has to perform the actual unadvise task within the COMThread of the Wrapper for which advise() was used.
The fix forwards the proper COMThread during EventProxy creation and executes the unadvise task with its help.