### PR TITLE
Add -addLibNametoPackageName option to tlbimp

### DIFF
--- a/tlbimp/src/main/java/com4j/tlbimp/driver/Driver.java
+++ b/tlbimp/src/main/java/com4j/tlbimp/driver/Driver.java
@@ -32,7 +32,7 @@ final class Driver {
     boolean renameGetterAndSetters = false;
     boolean alwaysUseComEnums = false;
     boolean generateDefaultMethodOverloads = false;
-
+    boolean addLibNameToPackageName = false;
 
     public void addLib( Lib r ) {
         libs.put(r.getLibid(),r);
@@ -72,10 +72,16 @@ final class Driver {
                 if( libid.equals(GUID.GUID_STDOLE))
                     return "";  // don't generate STDOLE. That's replaced by com4j runtime.
 
-                if( libsToGen.add(lib) )
+                String libPackageName = packageName;
+                if ( addLibNameToPackageName ) {
+                    String libName = lib.getName().toLowerCase();
+                    libPackageName = packageName.length() > 0 ? packageName + "." + libName : libName;
+                }
+
+                if( libsToGen.add(lib) && libPackageName.equals(packageName) )
                     el.warning(Messages.REFERENCED_TYPELIB_GENERATED.format(lib.getName(),packageName));
 
-                return packageName;
+                return libPackageName;
             }
 
             public boolean suppress(IWTypeLib lib) {

--- a/tlbimp/src/main/java/com4j/tlbimp/driver/Main.java
+++ b/tlbimp/src/main/java/com4j/tlbimp/driver/Main.java
@@ -49,6 +49,9 @@ public class Main implements ErrorListener {
     @Option(name="-alwaysUseComEnums",usage="Always use ComEnum for generating enums")
     public boolean alwaysUseComEnums = false;
 
+    @Option(name="-addLibNameToPackageName",usage="Append lower-case library name to package")
+    public boolean addLibNameToPackageName = false;
+
     @Argument
     private List<String> files = new ArrayList<String>();
 
@@ -125,6 +128,7 @@ public class Main implements ErrorListener {
 
         driver.alwaysUseComEnums = alwaysUseComEnums;
         driver.renameGetterAndSetters = javaGetterSetterName;
+        driver.addLibNameToPackageName = addLibNameToPackageName;
 
         try {
             if(locale!=null)


### PR DESCRIPTION
For some type libraries it can be useful to create seperate packages for
each library referenced by the type library.

For example, the Excel type library references Office and VBIDE and those
have conflicting class names if merged into a single package. Adding the
library name to the package name resolves that problem.