### PR TITLE
Add COM4J.wrapSta for wrapping STA com objects

### DIFF
--- a/runtime/src/main/java/com4j/ComThread.java
+++ b/runtime/src/main/java/com4j/ComThread.java
@@ -1,210 +1,24 @@
 package com4j;
 
 import java.lang.ref.ReferenceQueue;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Set;
-
 
 /**
- * Thread managed by com4j.
+ * Interface for threads managed by com4j.
  *
  * <p>
- * For each user thread that works with COM objects,
- * one {@link ComThread} is created to manage those objects.
+ * COM objects constructed via Com4j use {@link ComThreadMulti}, and
+ * those objects can be accessed from all Java threads.
+ *
+ * COM objects constructed outside of Com4j and wrapped that can only be
+ * accessed from the thread that created the object and use
+ * {@link ComThreadSingle}.
  *
  * <p>
  * This is because COM objects are inherently tied to the thread that created it,
  * and therefore all the invocations must be routed through the creator thread.
  * See http://msdn.microsoft.com/en-us/library/ms809971.aspx for more discussions.
- *
- * <p>
- * This model is rather alien to Java developers, where objects can be passed between
- * threads more freely. (This is a separate issue from whether those objects can be
- * safely accessed concurrently.)
- *
- * <p>
- * To bridge these gaps, we don't let application threads touch COM objects at all,
- * and instead create {@link ComThread} as a shadow thread for each application thread who wants to
- * create a COM object.
- *
- * @author Kohsuke Kawaguchi (kk@kohsuke.org)
- * @author Michael Schnell (ScM, (C) 2008, 2009, Michael-Schnell@gmx.de)
- * @author mpoindexter (staticsnow@gmail.com)
  */
-public final class ComThread extends Thread {
-
-	public static int GARBAGE_COLLECTION_INTERVAL = 10;
-    
-	/**
-     * Used to associate a {@link ComThread} for every thread.
-     */
-    private static final ThreadLocal<ComThread> map = new ThreadLocal<ComThread>() {
-        public ComThread initialValue() {
-            if( isComThread() )
-                return (ComThread)Thread.currentThread();
-            else
-                return new ComThread(Thread.currentThread());
-        }
-    };
-
-    /**
-     * Gets the {@link ComThread} associated with the current thread.
-     */
-    static ComThread get() {
-        return map.get();
-    }
-
-    /**
-     * Detaches the {@link ComThread} for the current thread (peer) by calling {@link #kill()}
-     */
-    static void detach() {
-        map.get().kill();
-        try {
-          map.get().join();
-        } catch (InterruptedException e) {
-          Thread.currentThread().interrupt();
-        }
-        map.remove();
-    }
-
-    /**
-     * Constructs a new ComThread for the given peer and starts it.
-     * @param peer The peer thread.
-     */
-    private ComThread(Thread peer) {
-        super("ComThread for "+peer.getName());
-        this.peer = peer;
-        setDaemon(true);    // we don't want to block the JVM from exiting
-        start();
-    }
-
-    /**
-     * The peer thread.
-     */
-    private final Thread peer;
-
-    /**
-     * Tasks that need to be processed.
-     */
-    private final List<Task<?>> taskList = Collections.synchronizedList((new LinkedList<Task<?>>()));// com4j issue 70
-
-    /**
-     * COM objects that this thread is managing. This thread needs to stick around until they are all gone,
-     * even when the peer is dead, because other threads might still want to talk to these objects.
-     */
-    private Set<NativePointerPhantomReference> liveComObjects = new HashSet<NativePointerPhantomReference>();
-
-    /**
-     * Keeps track of wrappers that should be IUnknown::release-d.
-     */
-    final ReferenceQueue<Wrapper> collectableObjects = new ReferenceQueue<Wrapper>();
-    
-    /**
-     * Listeners attached to this thread.
-     */
-    private final List<ComObjectListener> listeners = new ArrayList<ComObjectListener>();
-
-    /**
-     * If set to true, this thread will commit suicide.
-     */
-    private volatile boolean die = false;
-
-    /**
-     * Used instead of the monitor of an object, so that we can run
-     * a message loop while waiting.
-     */
-    private final Win32Lock lock = new Win32Lock();
-
-    /**
-     * Returns true if this thread can exit.
-     * <p>
-     * If die is true, this method returns true. Otherwise it returns true, if the peer thread is not
-     * alive any more and all liveObjects have been removed.
-     * </p>
-     */
-    private boolean canExit() {
-        // lhs:forcible death <->  rhs:natural death
-        return die || (!peer.isAlive() && liveComObjects.isEmpty());
-    }
-
-    /**
-     * Kills this {@link ComThread} gracefully
-     * and blocks until a thread dies.
-     */
-    public void kill() {
-        die = true;
-        lock.activate(); // wake up the sleeping thread.
-
-        // wait for it to die. if someone interrupts us, process that later.
-        try {
-            join();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
-    }
-
-    public void run() {
-        threads.add(this);
-        try {
-            run0();
-        } finally {
-            threads.remove(this);
-        }
-    }
-
-    private void run0() {
-        Native.coInitialize();
-
-        while(!canExit()) {
-            lock.suspend(GARBAGE_COLLECTION_INTERVAL);
-
-            //Clean up any com objects that need releasing
-            collectGarbage();
-
-            // do any scheduled tasks that need to be done
-            while (!taskList.isEmpty()) {
-                Task<?> task = taskList.get(0);
-                taskList.remove(0);
-                task.invoke();
-                
-                //Maybe the task produced some garbage...clean that up
-                collectGarbage();
-            }
-        }
-
-        collectGarbage();
-        
-        //And clobber any live COM objects that have not been dispose()'d to avoid
-        //leaking these objects on die
-        for(NativePointerPhantomReference ref : liveComObjects) {
-        	ref.clear();
-        	ref.releaseNative();
-        }
-        liveComObjects.clear();
-        
-        //Kill the event handle we are holding in the lock.
-        lock.dispose();
-
-        Native.coUninitialize();
-    }
-
-    /**
-     * Cleans up any left over references
-     */
-	private void collectGarbage() {
-		// dispose unused objects if any
-		NativePointerPhantomReference toCollect;
-		while((toCollect = (NativePointerPhantomReference)collectableObjects.poll()) != null) {
-		    liveComObjects.remove(toCollect);
-		    toCollect.clear();
-		    toCollect.releaseNative();
-		}
-	}
-
+public interface ComThread {
     /**
      * Executes a {@link Task} in a {@link ComThread}
      * and returns its result.
@@ -212,35 +26,17 @@ public final class ComThread extends Thread {
      * @param <T> The type of the return value.
      * @return The result of the Task
      */
-    public <T> T execute(Task<T> task) {
-        synchronized(task) {
-            task.reset();
-            // add it to the tail
-            taskList.add(task);
+    public <T> T execute(Task<T> task);
 
-            // invoke the execution
-            lock.activate();
+    /**
+     * Checks if the current thread this instance of ComThread;
+     */
+    boolean isCurrentThread();
 
-            // wait for the completion
-            try {
-            	while (!task.isDone()) {
-            		task.wait();
-            	}
-            } catch (InterruptedException e) {
-                task.exception = e; // we got interrupted, so task.result will be invalid! 
-            }
-
-            if(task.exception!=null) {
-                Throwable e = task.exception;
-                task.exception = null;
-                throw new ExecutionException(e);
-            } else {
-                T r = task.result;
-                task.result = null;
-                return r;
-            }
-        }
-    }
+    /**
+     * Keeps track of wrappers that should be IUnknown::release-d.
+     */
+    public ReferenceQueue<Wrapper> getCollectableObjects();
 
     /**
      * Adds a {@link Com4jObject} to the live objects of this {@link ComThread}
@@ -250,80 +46,19 @@ public final class ComThread extends Thread {
      * </p>
      * @param r The new {@link Com4jObject}
      */
-    public synchronized void addLiveObject( Com4jObject r ) {// TODO: why is this public?
-    	if(r instanceof Wrapper) {
-    		liveComObjects.add(((Wrapper)r).ref);
-    	}
-        
-        if(!listeners.isEmpty()) {
-            for( int i=listeners.size()-1; i>=0; i-- )
-                listeners.get(i).onNewObject(r);
-        }
-    }
-    
-    /**
-     * Checks if the current thread is a {@link ComThread}.
-     */
-    static boolean isComThread() {
-        return Thread.currentThread() instanceof ComThread;
-    }
+    public void addLiveObject( Com4jObject r );
 
     /**
      * Adds a {@link ComObjectListener} to this {@link ComThread}
      * @param listener the new listener
      * @throws IllegalArgumentException if the <code>listener</code> is <code>null</code> or if the listener is already registered.
      */
-    public void addListener(ComObjectListener listener) {
-        if(listener==null)
-            throw new IllegalArgumentException("listener is null");
-        if(listeners.contains(listener))
-            throw new IllegalArgumentException("can't register the same listener twice");
-        listeners.add(listener);
-    }
+    public void addListener(ComObjectListener listener);
 
     /**
      * Removes the {@link ComObjectListener} from this {@link ComThread}
      * @param listener The listener to remove
      * @throws IllegalArgumentException if the listener was not registered to this {@link ComThread}
      */
-    public void removeListener(ComObjectListener listener) {
-        if(!listeners.remove(listener))
-            throw new IllegalArgumentException("listener isn't registered");
-    }
-
-
-    /**
-     * All living and running {@link ComThread}s.
-     */
-    static final Set<ComThread> threads = Collections.synchronizedSet(new HashSet<ComThread>());
-
-    static {
-        // before shut-down clean up all ComThreads
-        COM4J.addCom4JShutdownTask(new Runnable() {
-            public void run() {
-              // we need to synchronize the access to threads.
-              // Not just to avoid concurrent modification, but also to make sure, that a kill-task is not waiting forever for the
-              // thread to execute the task. (The thread might want to shut down itself concurrently, because the liveObjects dropped to zero.)
-              ComThread[] threadsSnapshot;
-              synchronized(threads) {
-                threadsSnapshot = threads.toArray(new ComThread[threads.size()]);
-              }
-
-              for (ComThread thread : threadsSnapshot) {
-                  thread.kill();
-              }
-            }
-        });
-    }
-
-    /**
-     * This method calls System.gc() and executes a dummy task to initiate the corresponding
-     * ComThread to call dispose0() on all waiting objects.
-     *
-     * This method is mainly for debug purposes.
-     */
-    public static void flushFreeList() {
-        System.gc();
-        ComThread.get().lock.activate();
-    }
+    public void removeListener(ComObjectListener listener);
 }

--- a/runtime/src/main/java/com4j/ComThreadMulti.java
+++ b/runtime/src/main/java/com4j/ComThreadMulti.java
@@ -1,0 +1,338 @@
+package com4j;
+
+import java.lang.ref.ReferenceQueue;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+
+
+/**
+ * Thread managed by com4j.
+ *
+ * <p>
+ * For each user thread that works with COM objects,
+ * one {@link ComThreadMulti} is created to manage those objects.
+ *
+ * <p>
+ * This is because COM objects are inherently tied to the thread that created it,
+ * and therefore all the invocations must be routed through the creator thread.
+ * See http://msdn.microsoft.com/en-us/library/ms809971.aspx for more discussions.
+ *
+ * <p>
+ * This model is rather alien to Java developers, where objects can be passed between
+ * threads more freely. (This is a separate issue from whether those objects can be
+ * safely accessed concurrently.)
+ *
+ * <p>
+ * To bridge these gaps, we don't let application threads touch COM objects at all,
+ * and instead create {@link ComThreadMulti} as a shadow thread for each application thread who wants to
+ * create a COM object.
+ *
+ * @author Kohsuke Kawaguchi (kk@kohsuke.org)
+ * @author Michael Schnell (ScM, (C) 2008, 2009, Michael-Schnell@gmx.de)
+ * @author mpoindexter (staticsnow@gmail.com)
+ */
+public final class ComThreadMulti extends Thread implements ComThread {
+
+	public static int GARBAGE_COLLECTION_INTERVAL = 10;
+    
+	/**
+     * Used to associate a {@link ComThreadMulti} for every thread.
+     */
+    private static final ThreadLocal<ComThreadMulti> map = new ThreadLocal<ComThreadMulti>() {
+        public ComThreadMulti initialValue() {
+            if( Thread.currentThread() instanceof ComThreadMulti)
+                return (ComThreadMulti)Thread.currentThread();
+            else
+                return new ComThreadMulti(Thread.currentThread());
+        }
+    };
+
+    /**
+     * Gets the {@link ComThreadMulti} associated with the current thread.
+     */
+    static ComThreadMulti get() {
+        return map.get();
+    }
+
+    /**
+     * Detaches the {@link ComThreadMulti} for the current thread (peer) by calling {@link #kill()}
+     */
+    static void detach() {
+        map.get().kill();
+        try {
+          map.get().join();
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+        map.remove();
+    }
+
+    /**
+     * Constructs a new ComThread for the given peer and starts it.
+     * @param peer The peer thread.
+     */
+    private ComThreadMulti(Thread peer) {
+        super("ComThread for "+peer.getName());
+        this.peer = peer;
+        setDaemon(true);    // we don't want to block the JVM from exiting
+        start();
+    }
+
+    /**
+     * The peer thread.
+     */
+    private final Thread peer;
+
+    /**
+     * Tasks that need to be processed.
+     */
+    private final List<Task<?>> taskList = Collections.synchronizedList((new LinkedList<Task<?>>()));// com4j issue 70
+
+    /**
+     * COM objects that this thread is managing. This thread needs to stick around until they are all gone,
+     * even when the peer is dead, because other threads might still want to talk to these objects.
+     */
+    private Set<NativePointerPhantomReference> liveComObjects = new HashSet<NativePointerPhantomReference>();
+
+    /**
+     * Keeps track of wrappers that should be IUnknown::release-d.
+     */
+    final ReferenceQueue<Wrapper> collectableObjects = new ReferenceQueue<Wrapper>();
+
+    public ReferenceQueue<Wrapper> getCollectableObjects() {
+        return collectableObjects;
+    }
+
+    /**
+     * Listeners attached to this thread.
+     */
+    private final List<ComObjectListener> listeners = new ArrayList<ComObjectListener>();
+
+    /**
+     * If set to true, this thread will commit suicide.
+     */
+    private volatile boolean die = false;
+
+    /**
+     * Used instead of the monitor of an object, so that we can run
+     * a message loop while waiting.
+     */
+    private final Win32Lock lock = new Win32Lock();
+
+    /**
+     * Returns true if this thread can exit.
+     * <p>
+     * If die is true, this method returns true. Otherwise it returns true, if the peer thread is not
+     * alive any more and all liveObjects have been removed.
+     * </p>
+     */
+    private boolean canExit() {
+        // lhs:forcible death <->  rhs:natural death
+        return die || (!peer.isAlive() && liveComObjects.isEmpty());
+    }
+
+    /**
+     * Kills this {@link ComThreadMulti} gracefully
+     * and blocks until a thread dies.
+     */
+    public void kill() {
+        die = true;
+        lock.activate(); // wake up the sleeping thread.
+
+        // wait for it to die. if someone interrupts us, process that later.
+        try {
+            join();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    public void run() {
+        threads.add(this);
+        try {
+            run0();
+        } finally {
+            threads.remove(this);
+        }
+    }
+
+    private void run0() {
+        Native.coInitialize();
+
+        while(!canExit()) {
+            lock.suspend(GARBAGE_COLLECTION_INTERVAL);
+
+            //Clean up any com objects that need releasing
+            collectGarbage();
+
+            // do any scheduled tasks that need to be done
+            while (!taskList.isEmpty()) {
+                Task<?> task = taskList.get(0);
+                taskList.remove(0);
+                task.invoke();
+
+                // wake up the waiting thread
+                lock.activate();
+                
+                //Maybe the task produced some garbage...clean that up
+                collectGarbage();
+            }
+        }
+
+        collectGarbage();
+        
+        //And clobber any live COM objects that have not been dispose()'d to avoid
+        //leaking these objects on die
+        for(NativePointerPhantomReference ref : liveComObjects) {
+        	ref.clear();
+        	ref.releaseNative();
+        }
+        liveComObjects.clear();
+        
+        //Kill the event handle we are holding in the lock.
+        lock.dispose();
+
+        Native.coUninitialize();
+    }
+
+    /**
+     * Cleans up any left over references
+     */
+	private void collectGarbage() {
+		// dispose unused objects if any
+		NativePointerPhantomReference toCollect;
+		while((toCollect = (NativePointerPhantomReference)collectableObjects.poll()) != null) {
+		    liveComObjects.remove(toCollect);
+		    toCollect.clear();
+		    toCollect.releaseNative();
+		}
+	}
+
+    /**
+     * Executes a {@link Task} in a {@link ComThreadMulti}
+     * and returns its result.
+     * @param task The task to be executed
+     * @param <T> The type of the return value.
+     * @return The result of the Task
+     */
+    public <T> T execute(Task<T> task) {
+        synchronized(task) {
+            task.reset();
+            // add it to the tail
+            taskList.add(task);
+
+            // invoke the execution
+            lock.activate();
+
+            // wait for the completion
+            try {
+                while (!task.isDone()) {
+                    //Native.pumpWaitingMessages();
+                    task.wait();
+                }
+            }
+            catch (InterruptedException e) {
+                task.exception = e;
+            }
+
+            if(task.exception!=null) {
+                Throwable e = task.exception;
+                task.exception = null;
+                throw new ExecutionException(e);
+            } else {
+                T r = task.result;
+                task.result = null;
+                return r;
+            }
+        }
+    }
+
+    /**
+     * Adds a {@link Com4jObject} to the live objects of this {@link ComThreadMulti}
+     * <p>
+     * This method increases the live object count of this thread and fires an
+     * {@link ComObjectListener#onNewObject(Com4jObject)} event to all listeners.
+     * </p>
+     * @param r The new {@link Com4jObject}
+     */
+    public synchronized void addLiveObject( Com4jObject r ) {// TODO: why is this public?
+    	if(r instanceof Wrapper) {
+    		liveComObjects.add(((Wrapper)r).ref);
+    	}
+        
+        if(!listeners.isEmpty()) {
+            for( int i=listeners.size()-1; i>=0; i-- )
+                listeners.get(i).onNewObject(r);
+        }
+    }
+    
+    /**
+     * Checks if the current thread is this instance of ComThreadSafe;
+     */
+    public boolean isCurrentThread() {
+        return Thread.currentThread() == this;
+    }
+
+    /**
+     * Adds a {@link ComObjectListener} to this {@link ComThreadMulti}
+     * @param listener the new listener
+     * @throws IllegalArgumentException if the <code>listener</code> is <code>null</code> or if the listener is already registered.
+     */
+    public void addListener(ComObjectListener listener) {
+        if(listener==null)
+            throw new IllegalArgumentException("listener is null");
+        if(listeners.contains(listener))
+            throw new IllegalArgumentException("can't register the same listener twice");
+        listeners.add(listener);
+    }
+
+    /**
+     * Removes the {@link ComObjectListener} from this {@link ComThreadMulti}
+     * @param listener The listener to remove
+     * @throws IllegalArgumentException if the listener was not registered to this {@link ComThreadMulti}
+     */
+    public void removeListener(ComObjectListener listener) {
+        if(!listeners.remove(listener))
+            throw new IllegalArgumentException("listener isn't registered");
+    }
+
+
+    /**
+     * All living and running {@link ComThreadMulti}s.
+     */
+    static final Set<ComThreadMulti> threads = Collections.synchronizedSet(new HashSet<ComThreadMulti>());
+
+    static {
+        // before shut-down clean up all ComThreads
+        COM4J.addCom4JShutdownTask(new Runnable() {
+            public void run() {
+              // we need to synchronize the access to threads.
+              // Not just to avoid concurrent modification, but also to make sure, that a kill-task is not waiting forever for the
+              // thread to execute the task. (The thread might want to shut down itself concurrently, because the liveObjects dropped to zero.)
+              ComThreadMulti[] threadsSnapshot;
+              synchronized(threads) {
+                threadsSnapshot = threads.toArray(new ComThreadMulti[threads.size()]);
+              }
+
+              for (ComThreadMulti thread : threadsSnapshot) {
+                  thread.kill();
+              }
+            }
+        });
+    }
+
+    /**
+     * This method calls System.gc() and executes a dummy task to initiate the corresponding
+     * ComThread to call dispose0() on all waiting objects.
+     *
+     * This method is mainly for debug purposes.
+     */
+    public static void flushFreeList() {
+        System.gc();
+        ComThreadMulti.get().lock.activate();
+    }
+}

--- a/runtime/src/main/java/com4j/ComThreadSingle.java
+++ b/runtime/src/main/java/com4j/ComThreadSingle.java
@@ -1,0 +1,154 @@
+package com4j;
+
+import java.lang.ref.ReferenceQueue;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * ComThread that enforces all calls to a COM object are performed on the same
+ * thread that created the object.
+ *
+ * <p>
+ * Usually {@link ComThreadMulti} is used so that COM objects can be passed
+ * between threads, but when a COM object is constructed outside of Com4j
+ * it may not be possible to marshal it to one of the Com4j threads, and
+ * so this class is used instead.
+ *
+ * @author Tony Roberts (tony@pyxll.com)
+ */
+public class ComThreadSingle implements ComThread {
+
+    /**
+     * Used to associate a {@link ComThreadSingle} for every thread using this class.
+     */
+    private static final ThreadLocal<ComThreadSingle> map = new ThreadLocal<ComThreadSingle>() {
+        public ComThreadSingle initialValue() {
+            return new ComThreadSingle(Thread.currentThread());
+        }
+    };
+
+    /**
+     * Gets the {@link ComThreadSingle} associated with the current thread.
+     */
+    static ComThreadSingle get() {
+        return map.get();
+    }
+
+    /**
+     * COM objects that this thread is managing. This thread needs to stick around until they are all gone,
+     * even when the peer is dead, because other threads might still want to talk to these objects.
+     */
+    private Set<NativePointerPhantomReference> liveComObjects = new HashSet<NativePointerPhantomReference>();
+
+    /**
+     * Listeners attached to this thread.
+     */
+    private final List<ComObjectListener> listeners = new ArrayList<ComObjectListener>();
+
+    /**
+     * The actual thread.
+     */
+    private final Thread thread;
+
+    private ComThreadSingle(Thread thread) {
+        this.thread = thread;
+    }
+
+    public boolean isCurrentThread() {
+        return Thread.currentThread() == thread;
+    }
+
+    /**
+     * Keeps track of wrappers that should be IUnknown::release-d.
+     */
+    final ReferenceQueue<Wrapper> collectableObjects = new ReferenceQueue<Wrapper>();
+
+    public ReferenceQueue<Wrapper> getCollectableObjects() {
+        return collectableObjects;
+    }
+
+    /**
+     * Runs the task in the current thread, and checks that current thread
+     * is the one associated with this object.
+     */
+    public <T> T execute(Task<T> task) {
+        // Check we can execute on the current thread
+        if (!isCurrentThread()) {
+            throw new RuntimeException("Attempted to call COM object from the wrong thread");
+        }
+
+        // Call the task
+        T result = task.call();
+
+        // Collect any garbage produced by the call
+        // TODO call this periodically from a windows message loop for this thread
+        collectGarbage();
+
+        return result;
+    }
+
+    /**
+     * Adds a {@link Com4jObject} to the live objects of this {@link ComThreadMulti}
+     * <p>
+     * This method increases the live object count of this thread and fires an
+     * {@link ComObjectListener#onNewObject(Com4jObject)} event to all listeners.
+     * </p>
+     * @param r The new {@link Com4jObject}
+     */
+    public synchronized void addLiveObject( Com4jObject r ) {
+        if(r instanceof Wrapper) {
+            liveComObjects.add(((Wrapper)r).ref);
+        }
+
+        if(!listeners.isEmpty()) {
+            for( int i=listeners.size()-1; i>=0; i-- )
+                listeners.get(i).onNewObject(r);
+        }
+    }
+
+    /**
+     * Adds a {@link ComObjectListener} to this {@link ComThreadSingle}
+     * @param listener the new listener
+     * @throws IllegalArgumentException if the <code>listener</code> is <code>null</code> or if the listener is already registered.
+     */
+    public void addListener(ComObjectListener listener) {
+        if(listener==null)
+            throw new IllegalArgumentException("listener is null");
+        if(listeners.contains(listener))
+            throw new IllegalArgumentException("can't register the same listener twice");
+        listeners.add(listener);
+    }
+
+    /**
+     * Removes the {@link ComObjectListener} from this {@link ComThreadSingle}
+     * @param listener The listener to remove
+     * @throws IllegalArgumentException if the listener was not registered to this {@link ComThreadSingle}
+     */
+    public void removeListener(ComObjectListener listener) {
+        if(!listeners.remove(listener))
+            throw new IllegalArgumentException("listener isn't registered");
+    }
+
+    /**
+     * Cleans up any left over references
+     */
+    private void collectGarbage() {
+        // dispose unused objects if any
+        NativePointerPhantomReference toCollect;
+        while((toCollect = (NativePointerPhantomReference)collectableObjects.poll()) != null) {
+            liveComObjects.remove(toCollect);
+            toCollect.clear();
+            toCollect.releaseNative();
+        }
+    }
+
+    /**
+     * Collects uncollected garbage and removes thread local instance.
+     */
+    static void detach() {
+        get().collectGarbage();
+        map.remove();
+    }
+}

--- a/runtime/src/main/java/com4j/Variant.java
+++ b/runtime/src/main/java/com4j/Variant.java
@@ -739,7 +739,7 @@ public final class Variant extends Number {
     public <T extends Com4jObject> T object( final Class<T> type ) {
         // native method invocation changeType needs to happen in the COM thread, that is responsible for this variant
         // @see ComCollection#fetch
-        ComThread t = thread != null ? thread : ComThread.get();
+        ComThread t = thread != null ? thread : ComThreadMulti.get();
         return t.execute(new Task<T>() {
             public T call() {
                 Com4jObject wrapper = convertTo(Com4jObject.class);

--- a/runtime/src/main/java/com4j/Win32Lock.java
+++ b/runtime/src/main/java/com4j/Win32Lock.java
@@ -4,7 +4,7 @@ package com4j;
  * Represents a Win32 Event lock.
  *
  * <p>
- * We can't use Java synchronization for {@link ComThread},
+ * We can't use Java synchronization for {@link ComThreadMulti},
  * as it blocks incoming method dispatching requests.
  * We need to use this instead.
  *


### PR DESCRIPTION
Objects wrapped in this way can only be called from the same thread they
were created by (and wrapped in).

When using these wrapped objects calls to the COM object are done in the
same thread instead of using a second thread. This has the disadvantage
that these objects can't be passed around and used from anywhere, but
where a COM object has to be called from a specific thread it means they
can be used (mostly only a problem when the Java code is running in the
same process as an in-process COM server).

Fixes #68