### PR TITLE
Add option for defaulting LCID paramerters

### DIFF
--- a/tlbimp/src/main/java/com4j/tlbimp/Generator.java
+++ b/tlbimp/src/main/java/com4j/tlbimp/Generator.java
@@ -82,6 +82,11 @@ public final class Generator {
      */
     boolean generateDefaultMethodOverloads = true;
 
+    /**
+     * Default locale id for LCID parameters.
+     */
+    Integer defaultLcid = null;
+
     public Generator( CodeWriter writer, ReferenceResolver resolver, ErrorListener el, Locale locale ) {
         this.el = el;
         this.writer = writer;
@@ -99,6 +104,10 @@ public final class Generator {
 
     public void setGenerateDefaultMethodOverloads(boolean v) {
         this.generateDefaultMethodOverloads  = v;
+    }
+
+    public void setDefaultLcid(int lcid) {
+        this.defaultLcid = lcid;
     }
 
     /**

--- a/tlbimp/src/main/java/com4j/tlbimp/MethodBinder.java
+++ b/tlbimp/src/main/java/com4j/tlbimp/MethodBinder.java
@@ -151,7 +151,7 @@ abstract class MethodBinder
   private Parameter[] generateDefaults(){
     Parameter[] defParam = new Parameter[params.length];
     for (int i = 0; i < params.length; i++) {
-      if(params[i].isOptional()){
+      if(params[i].isOptional() || (params[i].isLCID() && g.defaultLcid != null)){
         TypeBinding vb;
         try {
           vb = TypeBinding.bind(g, params[i].getType(), params[i].getName());
@@ -161,6 +161,10 @@ abstract class MethodBinder
         }
         defParam[i] = new Parameter();
         Variant defValue = params[i].getDefaultValue();
+        if (defValue == null && params[i].isLCID() && null != g.defaultLcid) {
+          defValue = new Variant(Variant.Type.VT_I4);
+          defValue.set(g.defaultLcid);
+        }
         defParam[i].nativeType = vb.nativeType;
         defParam[i].javaTypeName = vb.javaType;
         if(defValue != null) {

--- a/tlbimp/src/main/java/com4j/tlbimp/driver/Driver.java
+++ b/tlbimp/src/main/java/com4j/tlbimp/driver/Driver.java
@@ -33,6 +33,7 @@ final class Driver {
     boolean alwaysUseComEnums = false;
     boolean generateDefaultMethodOverloads = false;
 
+    Integer defaultLcid = null;
 
     public void addLib( Lib r ) {
         libs.put(r.getLibid(),r);
@@ -96,6 +97,8 @@ final class Driver {
         generator.setAlwaysUseComEnums(alwaysUseComEnums);
         generator.setRenameGetterAndSetters(renameGetterAndSetters);
         generator.setGenerateDefaultMethodOverloads(generateDefaultMethodOverloads);
+        if (null != defaultLcid)
+            generator.setDefaultLcid(defaultLcid);
 
         // repeatedly generate all the libraries that need to be generated
         Set<IWTypeLib> generatedLibs = new HashSet<IWTypeLib>();

--- a/tlbimp/src/main/java/com4j/tlbimp/driver/Main.java
+++ b/tlbimp/src/main/java/com4j/tlbimp/driver/Main.java
@@ -49,6 +49,9 @@ public class Main implements ErrorListener {
     @Option(name="-alwaysUseComEnums",usage="Always use ComEnum for generating enums")
     public boolean alwaysUseComEnums = false;
 
+    @Option(name="-defaultLcid",usage="Default locale id for LCID parameters")
+    public Integer defaultLcid;
+
     @Argument
     private List<String> files = new ArrayList<String>();
 
@@ -125,6 +128,7 @@ public class Main implements ErrorListener {
 
         driver.alwaysUseComEnums = alwaysUseComEnums;
         driver.renameGetterAndSetters = javaGetterSetterName;
+        driver.defaultLcid = defaultLcid;
 
         try {
             if(locale!=null)


### PR DESCRIPTION
It's common for COM methods to take the locale id as the last parameter,
but in most cases it can be defaulted to 1033 (US).