### PR TITLE
Correct buffer size to fix memory corruption

### DIFF
--- a/runtime/src/main/java/com4j/Variant.java
+++ b/runtime/src/main/java/com4j/Variant.java
@@ -364,18 +364,20 @@ public final class Variant extends Number {
      * definition.  See https://docs.microsoft.com/en-gb/windows/desktop/api/oaidl/ns-oaidl-tagvariant
      */
     private static int variantSize() {
-        String model = System.getProperty("sun.arch.data.model");
-        if (model.equals("64")) {
+	/* Typical os.arch values: `x86_64`, `amd64` */
+        String model = System.getProperty("os.arch");
+        if (model.indexOf("64") != -1) {
             return 24;
         }
         return 16;
     }
 
+    private static final int variantSize = variantSize();
+
     /**
      * Creates an empty {@link Variant}.
      */
     public Variant() {
-        final int variantSize = variantSize();
         image = ByteBuffer.allocateDirect(variantSize);
         image.order(ByteOrder.LITTLE_ENDIAN);
         // The initial content of a buffer is, in general, undefined. See the documentation of java.nio.Buffer.

--- a/runtime/src/main/java/com4j/Variant.java
+++ b/runtime/src/main/java/com4j/Variant.java
@@ -357,13 +357,29 @@ public final class Variant extends Number {
     }
 
     /**
+     * Determine the correct size of {@link Variant}.
+     *
+     * The size of the variant depends on whether this is
+     * a 32 or 64 bit system due to pointers in the structure
+     * definition.  See https://docs.microsoft.com/en-gb/windows/desktop/api/oaidl/ns-oaidl-tagvariant
+     */
+    private static int variantSize() {
+        String model = System.getProperty("sun.arch.data.model");
+        if (model.equals("64")) {
+            return 24;
+        }
+        return 16;
+    }
+
+    /**
      * Creates an empty {@link Variant}.
      */
     public Variant() {
-        image = ByteBuffer.allocateDirect(24);
+        final int variantSize = variantSize();
+        image = ByteBuffer.allocateDirect(variantSize);
         image.order(ByteOrder.LITTLE_ENDIAN);
         // The initial content of a buffer is, in general, undefined. See the documentation of java.nio.Buffer.
-        byte[] b = new byte[24]; // this initializes the array with zeros
+        byte[] b = new byte[variantSize]; // this initializes the array with zeros
         image.put(b); // this prints the zeros to the buffer to guarantee, that the buffer is initialized with zeros.
         image.position(0);
     }

--- a/runtime/src/main/java/com4j/Variant.java
+++ b/runtime/src/main/java/com4j/Variant.java
@@ -360,10 +360,10 @@ public final class Variant extends Number {
      * Creates an empty {@link Variant}.
      */
     public Variant() {
-        image = ByteBuffer.allocateDirect(16);
+        image = ByteBuffer.allocateDirect(24);
         image.order(ByteOrder.LITTLE_ENDIAN);
         // The initial content of a buffer is, in general, undefined. See the documentation of java.nio.Buffer.
-        byte[] b = new byte[16]; // this initializes the array with zeros
+        byte[] b = new byte[24]; // this initializes the array with zeros
         image.put(b); // this prints the zeros to the buffer to guarantee, that the buffer is initialized with zeros.
         image.position(0);
     }


### PR DESCRIPTION
The analysis in eclipse/openj9#5696 shows that there
is a out of bounds access that is fixed by increasing
the buffer size by 8.  Validated by having the VM
increase all unsafe allocates by 8 and the problem
no longer occurs.

fixes: #79

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>